### PR TITLE
Cross platform composer "post-autoload-dump" script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "scripts": {
         "post-autoload-dump": [
-            "cp lib/cockpit/cp ./cp && cp ./cp ./mp",
+            "php -r \"copy('lib/cockpit/cp', './cp'); copy('./cp', './mp');\";",
             "php ./mp multiplane/update-htaccess"
         ]
     }


### PR DESCRIPTION
Replace `cp` bash command (as is not available on Windows OS) with an equivalent inline php `copy()` script.